### PR TITLE
Optimized `SVector::add()`

### DIFF
--- a/src/svector/svector.cpp
+++ b/src/svector/svector.cpp
@@ -77,6 +77,11 @@ void SVector::add(const SVector& a, const Value& C)
 */
 
 // More complicated version without using temporary variable
+/*
+On complexity ...
+For random vectors of length N the use of insert makes this O(N^2). In practice it is rare for the
+input svector `a` to have many elements not in this svector, so insert is rarely called
+*/
 void SVector::add(const SVector& a, const Value& C)
 {
     // quick exit


### PR DESCRIPTION
## Changes

Do addition in place rather than creating a temporary variable.

## Performance

Typically, when `SVector::add(a)` is called most if not all of the non-zero labels in `a` are also non-zero in `this`. This change optimizes for the case where the same elements are non-zero in each vector. For a vectors of length $N$, worst-case scaling is now $O(N^2)$ due to $N$ calls to the $O(N)$ `insert` operation. However, typical operation (when `insert` is rarely called) is significantly improved.

