### PR TITLE
Remove very small values with `ELA_SolverNormalizeLabel()`

### DIFF
--- a/src/ELA_Solver.cpp
+++ b/src/ELA_Solver.cpp
@@ -60,12 +60,15 @@ void ELA_SolverNormalizeLabel(const double* vof_in)
         auto f = vofField.begin();
 
         for (auto& sVector : ela::dom->s[n]) {
-            // ensure there are no negative values
-            sVector.chop();
+            // calculate 1-f
+            const svec::Value& fInv = 1.0 - *(f++);
+
+            // remove very small (compared to 1-f) values of s
+            sVector.chop(fInv);
 
             // ensure sum(s)=1-f
             // ELA paper eq. 47
-            sVector.normalize(1.0 - *(f++));
+            sVector.normalize(fInv);
         }
     }
 }

--- a/src/ELA_Solver.h
+++ b/src/ELA_Solver.h
@@ -62,8 +62,8 @@ void ELA_SolverDilateLabels(const double* u_div);
  * @brief Cleanup machine precision related errors, including @cite Gaylo2022, Eq. 47
  *
  * This function does two cleanup operations.
- * First, it sets any \f$s_l<0\f$ to \f$s_l=0\f$.
- * Second, it performs the normalization (@cite Gaylo2022, Eq. 47):
+ * First, it sets any \f$s_l\le\varepsilon (1-f)\f$ to \f$s_l=0\f$, where \f$ \varepsilon \f$ is
+ * machine precision. Second, it performs the normalization (@cite Gaylo2022, Eq. 47):
  * \f[
  * \mathbf{s} \gets (1-f) \; \hat{\mathbf{s}},
  * \f]

--- a/src/svector/svector.cpp
+++ b/src/svector/svector.cpp
@@ -153,11 +153,13 @@ void SVector::normalize(const Value& total)
     }
 }
 
-void SVector::chop()
+void SVector::chop(const Value& ref)
 {
+    Value minV = std::numeric_limits<Value>::epsilon() * ref;
+
     // remove any values <= 0
-    auto itr = std::remove_if(vec.begin(), vec.end(), [](const svec::Element& elm) {
-        return elm.v <= 0.0;
+    auto itr = std::remove_if(vec.begin(), vec.end(), [&minV](const svec::Element& elm) {
+        return elm.v <= minV;
     });
 
     vec.erase(itr, vec.end());

--- a/src/svector/svector.h
+++ b/src/svector/svector.h
@@ -170,10 +170,14 @@ class SVector {
     void normalize(const Value& total = 1.0);
 
     /**
-     * @brief remove any values <= 0
+     * @brief Remove small elements in s
      *
+     * For any \f$s_l\le \varepsilon R \f$, \f$ s_l \gets 0 \f$. Where \f$ \varepsilon \f$ is
+     * machine precision.
+     *
+     * @param ref \f$ R \f$
      */
-    void chop();
+    void chop(const Value& ref = 0.0);
 
     /**
      * @brief Set the entry at label \p l to zero

--- a/src/svector/tests/svector_test.cpp
+++ b/src/svector/tests/svector_test.cpp
@@ -179,12 +179,17 @@ TEST(SVectorTests, Add)
 
 TEST(SVectorTests, Chop)
 {
-    svec::Element buff[7] = {{0, 5},  {1, -0.1}, {3, 0.2},         {4, 0.8},
-                             {8, -5}, {9, 0.0},  svec::END_ELEMENT};
+    svec::Element buff[7] = {{0, 5},           {1, -0.1},
+                             {3, 0.2},         {4, 0.8},
+                             {8, -5},          {9, std::numeric_limits<svec::Value>::epsilon() / 2},
+                             svec::END_ELEMENT};
     svec::SVector s = svec::SVector(buff);
 
     s.chop();
+    EXPECT_EQ(s.NNZ(), 4);
+    EXPECT_DOUBLE_EQ(s.sum(), 5 + 0.2 + 0.8);
 
+    s.chop(1.0);
     EXPECT_EQ(s.NNZ(), 3);
     EXPECT_DOUBLE_EQ(s.sum(), 5 + 0.2 + 0.8);
 }


### PR DESCRIPTION
Previously, `chop()` in ELA_SolverNormalizeLabel()` would set $s_l$ to zero if $s_l \le 0$. Now, $s_l$ is set to zero if $s_l \le \varepsilon f$ where $\varepsilon$ is machine precision and $f$ is the cells void fraction.

For realistic use cases, this can significantly decrease the number of non-zero entries per cell. While there is theoretically some conservation error, it is on the level of machine precision.